### PR TITLE
Fix /tmp/.docker.xauth does not exist

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,7 @@ fi
 
 XSOCK=/tmp/.X11-unix
 XAUTH=/tmp/.docker.xauth
+touch $XAUTH
 xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
 
 docker run \


### PR DESCRIPTION
This commit will prevent the following warning from being displayed when running a docker image:

```
/tmp/.docker.xauth does not exist
```
